### PR TITLE
Fix env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -40,7 +40,7 @@ GF_AUTH_ANONYMOUS_ENABLED="true"
 INFLUXDB_DB="covina"
 
 # Enables authentication. Either this must be set or auth-enabled = true must be set within the configuration file for any authentication related options below to work.
-INFLUXDB_HTTP_AUTH_ENABLED="true"
+INFLUXDB_HTTP_AUTH_ENABLED=true
 
 #
 # Covina


### PR DESCRIPTION
If INFLUXDB_HTTP_AUTH_ENABLED is set to `"true"` (using double-quotes) then InfluxDB can't start and show this error:
```
run: apply env config: failed to apply INFLUXDB_HTTP_AUTH_ENABLED to AuthEnabled using type bool and value '"true"': strconv.ParseBool: parsing "\"true\"": invalid syntax
```